### PR TITLE
Include editorconfig core when installing

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -23,3 +23,11 @@ echo "Copying $installfiles to $installdir..."
 mkdir -p $installdir &&
 cp -rfL $installfiles $installdir &&
 echo "Done."
+echo ""
+echo "Installing EditorConfig Python Core..."
+cd editorconfig-core-py
+if [ "$(id -u)" -ne "0" ] ; then
+    python setup.py install --user
+else
+    python setup.py install
+fi


### PR DESCRIPTION
The install script didn't include installing the core library, leaving the plugin broken; this addition installs the entire package.

Side note: my gedit seems to use my home directory as its working directory, so when shared.py appends `abspath('../editorconfig-core-py/')` to `sys.path`, it actually added `'/home/editorconfig-core-py'`. I didn't remove this as it seems to be harmless, but you may want to take a look at this as well.
