### PR TITLE
Assume gedit 3 is the default for install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,19 +5,19 @@ minorversion=$(gedit --version | sed -n 's/gedit.*\s[0-9]\.\([0-9]*\).*/\1/p')
 installfiles="editorconfig_plugin/"
 editorconfigcore="editorconfig-core-py/"
 
-if [ "$majorversion" -eq "3" ] ; then
-    localinstalldir=~/.local/share/gedit/plugins
-    rootinstalldir=/usr/lib/gedit/plugins
-    installfiles="$installfiles $editorconfigcore editorconfig_gedit3.py editorconfig.plugin"
-else
+localinstalldir=~/.local/share/gedit/plugins
+rootinstalldir=/usr/lib/gedit/plugins
+installfiles="$installfiles $editorconfigcore editorconfig_gedit3.py editorconfig.plugin"
+
+if [ "$majorversion" -lt "3" ] ; then
     localinstalldir=~/.gnome2/gedit/plugins
     rootinstalldir=/usr/lib/gedit-2/plugins
     installfiles="$installfiles $editorconfigcore editorconfig_gedit2.py editorconfig.gedit-plugin"
 fi
 
-if [ "$(id -u)" -ne "0" ] ; then
-    installdir=$localinstalldir
-else
+installdir=$localinstalldir
+
+if [ "$(id -u)" -eq "0" ] ; then
     installdir=$rootinstalldir
 fi
 
@@ -26,8 +26,8 @@ mkdir -p $installdir &&
 cp -rfL $installfiles $installdir &&
 echo "Done."
 
-if [ "$majorversion" -eq "3" -a "$minorversion" -ge "8" ] ; then
-    echo "Patching $installdir/editorconfig.plugin for Python 3 support..."
-    sed -i 's/python/python3/' "$installdir/editorconfig.plugin" &&
+if [ "$majorversion" -eq "3" -a "$minorversion" -lt "8" ] ; then
+    echo "Patching $installdir/editorconfig.plugin for Python 2 support..."
+    sed -i 's/python3/python/' "$installdir/editorconfig.plugin" &&
     echo "Done."
 fi


### PR DESCRIPTION
This changes install.sh to:
* assume gedit 3 is the default version and test for older versions
* assume a normal user and test for root user
* fix patching of editorconfig.plugin, since it already uses the python 3 loader