### PR TITLE
Fix core library import path

### DIFF
--- a/editorconfig_plugin/shared.py
+++ b/editorconfig_plugin/shared.py
@@ -1,8 +1,10 @@
-from os.path import abspath
+import os
 import sys
 import logging
 
-editorconfig_path = abspath('editorconfig-core-py/')
+plugin_dir = os.path.dirname(__file__)
+lib_dir = os.path.join(plugin_dir, '..', 'editorconfig-core-py')
+editorconfig_path = os.path.abspath(lib_dir)
 if editorconfig_path not in sys.path:
     sys.path.append(editorconfig_path)
 


### PR DESCRIPTION
The gedit plugin working directory isn't documented, and as such can change from version to version. This is the root cause of #9.

This changes the core library path to be computed based on the location of `shared.py`, instead of assuming the plugin working directory. This should finally allow the plugin to use the bundled core library instead of having to install the library separately.