### PR TITLE
README: Remove end_of_line from support list

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ The EditorConfig Gedit plugin fully supports the following EditorConfig
 [properties][]:
 
 * indent_style
-* end_of_line
 * trim_trailing_whitespace
+* end_of_line (only in Gedit <= 3.14)
 * root (only used by EditorConfig core)
 
 There is partial support for the following properties:


### PR DESCRIPTION
`end_of_line` can no longer be supported due to Gedit API changes (see #23)