### PR TITLE
Patch around GEdit 3.36 API breakage

### DIFF
--- a/editorconfig_plugin/gedit3.py
+++ b/editorconfig_plugin/gedit3.py
@@ -41,7 +41,7 @@ class EditorConfigPlugin(GObject.Object, Gedit.WindowActivatable,
     def get_document_properties(self, document):
         """Call EditorConfig core and return properties dict for document"""
         if document:
-            location = document.get_location()
+            location = document.get_file().get_location()
             if location:
                 file_uri = location.get_uri()
                 if file_uri.startswith('file:///'):


### PR DESCRIPTION
Seems GEdit 3.36 changes the document location API for no discernible reason. Now,
```python3
# instead of
document.get_location().get_uri()
# it's
document.get_file().get_location().get_uri()
```

(Waiting for `.get_scheme().get_path().get_string().get_first_character()`... :roll_eyes: )

Eliminates constant annoying message like this in the terminal:
```
Traceback (most recent call last):
  File "/usr/lib64/gedit/plugins/editorconfig_plugin/shared.py", line 34, in set_config
    props = self.get_document_properties(document)
  File "/usr/lib64/gedit/plugins/editorconfig_plugin/gedit3.py", line 44, in get_document_properties
    location = document.get_location()
AttributeError: 'Document' object has no attribute 'get_location'
```

Many thanks to developer @maoschanz who already sorted this out in maoschanz/gedit-plugin-markdown_preview#23, and made it real easy to crib from their code after a web search.