### PR TITLE
fix unable to parse filename with spaces

### DIFF
--- a/editorconfig_plugin/gedit2.py
+++ b/editorconfig_plugin/gedit2.py
@@ -24,6 +24,7 @@
 #
 
 import gedit
+from urllib.parse import unquote, urlparse
 from .shared import EditorConfigPluginMixin
 
 
@@ -39,6 +40,5 @@ class EditorConfigPlugin(gedit.Plugin, EditorConfigPluginMixin):
         """Call EditorConfig core and return properties dict for document"""
         if document:
             file_uri = document.get_uri()
-            if file_uri and file_uri.startswith("file:///"):
-                return self.get_properties_from_filename(file_uri[7:])
+            return self.get_properties_from_filename(unquote(urlparse(file_uri).path))
         return {}

--- a/editorconfig_plugin/gedit3.py
+++ b/editorconfig_plugin/gedit3.py
@@ -23,6 +23,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
+from urllib.parse import unquote, urlparse
 from gi.repository import GObject, Gedit
 from .shared import EditorConfigPluginMixin
 
@@ -44,6 +45,5 @@ class EditorConfigPlugin(GObject.Object, Gedit.WindowActivatable,
             location = document.get_file().get_location()
             if location:
                 file_uri = location.get_uri()
-                if file_uri.startswith('file:///'):
-                    return self.get_properties_from_filename(file_uri[7:])
+                return self.get_properties_from_filename(unquote(urlparse(file_uri).path))
         return {}


### PR DESCRIPTION
This is done by parsing file URI's with `urllib` standard library instead of picking a substring at a specified offset

Therefore `file:///my%20dir/my%20file.c` will be read as `/my dir/my file.c` instead of `/my%20dir/my%20file.c` which results in file not found and causes plugin to not working